### PR TITLE
Feature/chainedroles

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: [3.9]
 
     steps:
-      - name: Checkout sources
+      - name: Checkout source
         uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -51,7 +51,7 @@ jobs:
           then
             echo "::set-output name=toxenv::py39"
           else
-            echo "::set-output name=toxenv::py39"
+            echo "::set-output name=toxenv::py310"
           fi
 
       - name: Test with tox

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
-      - name: Checkout sources
+      - name: Checkout source
         uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -51,7 +51,7 @@ jobs:
           then
             echo "::set-output name=toxenv::py39"
           else
-            echo "::set-output name=toxenv::py39"
+            echo "::set-output name=toxenv::py310"
           fi
 
       - name: Test with tox

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,7 @@
+0.4.0 - 2022-01-25
+==================
+- Updated `awslogin chained` to support option `--from-profile|-p` for showing chained roles from the ~/.aws/config for the given profile (specified with `from-profile|-p`).
+
 0.3.1 - 2021-10-20
 ==================
 - Support parsing info of AWS account that does not have account alias when calling `saml2aws list-roles`.

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,5 +1,4 @@
 # This file is used for running tox, flake8 and building the wheel
 logilab-common~=1.7
-m2r~=0.2
 tox~=3.16
 virtualenv~=20.0

--- a/saml2awsmulti/aws_login.py
+++ b/saml2awsmulti/aws_login.py
@@ -120,14 +120,16 @@ def main_cli(ctx, shortlisted, pre_select, profile_name_format, refresh_cached_r
 
 
 @main_cli.command(help="List chained role profiles specified in ~/.aws/config")
-def chained():
+@click.option("--from-profile", "-p", help="List chained roles for the given profile name.")
+def chained(from_profile):
     config = get_aws_profiles(AWS_CONF_FILE)
-    profiles = [
-        profile.replace("profile ", "")
-        for profile in config.sections()
-        if config[profile].get("source_profile")
-        and config[profile].get("role_arn")
-    ]
+
+    profiles = []
+    for profile in config.sections():
+        if config[profile].get("source_profile") and config[profile].get("role_arn"):
+
+            if from_profile is None or from_profile == config[profile].get("source_profile"):
+                profiles.append(profile.replace("profile ", ""))
 
     logging.info(f"Found {len(profiles)} chained role profiles")
     cnt = 1

--- a/saml2awsmulti/aws_login.py
+++ b/saml2awsmulti/aws_login.py
@@ -10,18 +10,12 @@ from pathlib import Path
 import click
 from boto3.session import Session
 
-from saml2awsmulti.file_io import (
-    get_aws_profiles,
-    read_csv,
-    read_lines_from_file,
-    write_aws_profiles,
-    write_csv,
-)
+from saml2awsmulti.file_io import (get_aws_profiles, read_csv,
+                                   read_lines_from_file, write_aws_profiles,
+                                   write_csv)
 from saml2awsmulti.saml2aws_helper import Saml2AwsHelper
-from saml2awsmulti.selector import (
-    prompt_profile_selection,
-    prompt_roles_selection,
-)
+from saml2awsmulti.selector import (prompt_profile_selection,
+                                    prompt_roles_selection)
 
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
@@ -30,20 +24,14 @@ AWS_CONF_FILE = join(str(Path.home()), ".aws", "config")
 AWS_CRED_FILE = join(str(Path.home()), ".aws", "credentials")
 SAML2AWS_CONFIG_FILE = join(str(Path.home()), ".saml2aws")
 USER_DATA_HOME = join(str(Path.home()), ".saml2aws-multi")
-ALL_ROLES_FILE = join(
-    USER_DATA_HOME, "aws_login_roles.csv"
-)  # role_arn, account_alias
-LAST_SELECTED_FILE = join(
-    USER_DATA_HOME, "aws_login_last_selected.txt"
-)  # aws_profile_name
+ALL_ROLES_FILE = join(USER_DATA_HOME, "aws_login_roles.csv")  # role_arn, account_alias
+LAST_SELECTED_FILE = join(USER_DATA_HOME, "aws_login_last_selected.txt")  # aws_profile_name
 
 DEFAULT_PROFILE_NAME_FORMAT = "RoleName"
 PROFILE_NAME_FORMATS = ["RoleName", "RoleName-AccountAlias"]
 
 
-def create_profile_name_from_role_arn(
-    role_arn, account_alias, profile_name_format
-):
+def create_profile_name_from_role_arn(role_arn, account_alias, profile_name_format):
     """Create a profile name for a give role ARN and account alias."""
     profile_name = role_arn.split("role/")[-1].replace("/", "-")
     if profile_name_format == "RoleName-AccountAlias":
@@ -51,9 +39,7 @@ def create_profile_name_from_role_arn(
     return profile_name
 
 
-def create_profile_rolearn_dict(
-    saml2aws_helper, profile_name_format, refresh_cached_roles, keywords
-):
+def create_profile_rolearn_dict(saml2aws_helper, profile_name_format, refresh_cached_roles, keywords):
     """Create an OrderedDict containing a full or shortlisted of {profile_name: role_arn}"""
     if refresh_cached_roles or not exists(ALL_ROLES_FILE):
         rolearn_alias_list = saml2aws_helper.run_saml2aws_list_roles()
@@ -63,18 +49,10 @@ def create_profile_rolearn_dict(
 
     profile_rolearn_dict = OrderedDict()
     for role_arn, account_alias in rolearn_alias_list:
-        profile_name = create_profile_name_from_role_arn(
-            role_arn, account_alias, profile_name_format
-        )
+        profile_name = create_profile_name_from_role_arn(role_arn, account_alias, profile_name_format)
 
         # If keywords defined, return only roles with profile_name matching any of the keywords
-        if (
-            len(keywords) == 0
-            or len(
-                [keyword for keyword in keywords if keyword in profile_name]
-            )
-            > 0
-        ):
+        if len(keywords) == 0 or len([keyword for keyword in keywords if keyword in profile_name]) > 0:
             profile_rolearn_dict[profile_name] = role_arn
 
     return profile_rolearn_dict
@@ -85,9 +63,7 @@ def pre_select_options(profile_rolearn_dict, keywords):
     pre_select_profiles = read_lines_from_file(LAST_SELECTED_FILE)
 
     # Make sure the previous selected role is still a valid role
-    pre_select_profiles = [
-        p for p in pre_select_profiles if p in profile_rolearn_dict.keys()
-    ]
+    pre_select_profiles = [p for p in pre_select_profiles if p in profile_rolearn_dict.keys()]
 
     for profile_name, role_arn in profile_rolearn_dict.items():
         for k in keywords:
@@ -97,62 +73,23 @@ def pre_select_options(profile_rolearn_dict, keywords):
     return pre_select_profiles
 
 
-@click.group(
-    invoke_without_command=True,
-    help="Get credentials for multiple accounts with saml2aws",
-)
-@click.option(
-    "--shortlisted",
-    "-l",
-    multiple=True,
-    help="Show only roles with the given keyword(s); e.g. -l keyword1 -l keyword2...",
-)
-@click.option(
-    "--pre-select",
-    "-s",
-    multiple=True,
-    help="Pre-select roles with the given keyword(s); e.g. -s keyword1 -s keyword2...",
-)
-@click.option(
-    "--profile-name-format",
-    "-n",
-    default=DEFAULT_PROFILE_NAME_FORMAT,
-    show_default=True,
-    help="Set the profile name format.",
-    type=click.Choice(PROFILE_NAME_FORMATS, case_sensitive=False),
-)
-@click.option(
-    "--refresh-cached-roles",
-    "-r",
-    is_flag=True,
-    show_default=True,
-    help="Re-retrieve the roles associated to the username and password you provided"
-    f"and save the roles into {ALL_ROLES_FILE}.",
-)
-@click.option(
-    "--session-duration", "-t", help="Set the session duration in seconds,"
-)
-@click.option(
-    "--debug", "-d", is_flag=True, show_default=True, help="Enable debug mode."
-)
+@click.group(invoke_without_command=True, help="Get credentials for multiple accounts with saml2aws")
+@click.option("--shortlisted", "-l", multiple=True, help="Show only roles with the given keyword(s); e.g. -l keyword1 -l keyword2...")
+@click.option("--pre-select", "-s", multiple=True, help="Pre-select roles with the given keyword(s); e.g. -s keyword1 -s keyword2...")
+@click.option("--profile-name-format", "-n", default=DEFAULT_PROFILE_NAME_FORMAT, show_default=True,
+    help="Set the profile name format.", type=click.Choice(PROFILE_NAME_FORMATS, case_sensitive=False))
+@click.option("--refresh-cached-roles", "-r", is_flag=True, show_default=True,
+    help=f"Re-retrieve the roles associated to the username and password you provided and save the roles into {ALL_ROLES_FILE}.")
+@click.option("--session-duration", "-t", help="Set the session duration in seconds.")
+@click.option("--debug", "-d", is_flag=True, show_default=True, help="Enable debug mode.")
 @click.pass_context
-def main_cli(
-    ctx,
-    shortlisted,
-    pre_select,
-    profile_name_format,
-    refresh_cached_roles,
-    session_duration,
-    debug,
-):
+def main_cli(ctx, shortlisted, pre_select, profile_name_format, refresh_cached_roles, session_duration, debug):
     if debug:
         logging.getLogger().setLevel(logging.DEBUG)
 
     if ctx.invoked_subcommand is None:
         try:
-            saml2aws_helper = Saml2AwsHelper(
-                SAML2AWS_CONFIG_FILE, session_duration
-            )
+            saml2aws_helper = Saml2AwsHelper(SAML2AWS_CONFIG_FILE, session_duration)
 
             profile_rolearn_dict = create_profile_rolearn_dict(
                 saml2aws_helper,
@@ -160,18 +97,12 @@ def main_cli(
                 refresh_cached_roles,
                 shortlisted,
             )
-            pre_select_profiles = pre_select_options(
-                profile_rolearn_dict, pre_select
-            )
+            pre_select_profiles = pre_select_options(profile_rolearn_dict, pre_select)
 
-            answers = prompt_roles_selection(
-                profile_rolearn_dict.keys(), pre_select_profiles
-            )
+            answers = prompt_roles_selection(profile_rolearn_dict.keys(), pre_select_profiles)
             if answers.get("roles"):
                 for profile in answers["roles"]:
-                    saml2aws_helper.run_saml2aws_login(
-                        profile_rolearn_dict[profile], profile
-                    )
+                    saml2aws_helper.run_saml2aws_login(profile_rolearn_dict[profile], profile)
 
                 # Dump the last selected options
                 with open(LAST_SELECTED_FILE, "w") as f:
@@ -180,14 +111,11 @@ def main_cli(
                 logging.info("Nothing selected. Aborted.")
         except FileNotFoundError as e:
             if e.filename == SAML2AWS_CONFIG_FILE:
-                logging.error(
-                    f"{e}. See https://github.com/Versent/saml2aws to create one."
-                )
+                logging.error(f"{e}. See https://github.com/Versent/saml2aws to create one.")
             else:
                 logging.error(f"Error: {e} Aborted.")
-        except Exception as e:
+        except Exception:
             import traceback
-
             traceback.print_exc()
 
 
@@ -211,9 +139,7 @@ def chained():
 @main_cli.command(help="Switch default profile")
 def switch():
     cred_config = get_aws_profiles(AWS_CRED_FILE)
-    options = [
-        profile for profile in cred_config.sections() if profile != "default"
-    ]
+    options = [profile for profile in cred_config.sections() if profile != "default"]
     if options:
         answer = prompt_profile_selection(options)
         profile = answer.get("profile")
@@ -228,18 +154,10 @@ def switch():
 
 
 @main_cli.command(help="Who am I?")
-@click.option(
-    "--profile",
-    "-p",
-    default="default",
-    show_default=True,
-    help="Profile name",
-)
+@click.option("--profile", "-p", default="default", show_default=True, help="Profile name")
 def whoami(profile):
     try:
-        resp = (
-            Session(profile_name=profile).client("sts").get_caller_identity()
-        )
+        resp = Session(profile_name=profile).client("sts").get_caller_identity()
         del resp["ResponseMetadata"]
         print(json.dumps(resp, indent=2, sort_keys=True))
     except Exception as e:

--- a/saml2awsmulti/saml2aws_helper.py
+++ b/saml2awsmulti/saml2aws_helper.py
@@ -34,9 +34,8 @@ class Saml2AwsHelper:
 
         cmd = f"saml2aws list-roles --username={uname} --password={upass} --skip-prompt"
 
-        p = subprocess.Popen(
-            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-        )
+        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
         for line in p.stdout.readlines():
             line = line.decode("utf-8").rstrip("\r|\n")
             logging.debug(line)
@@ -44,14 +43,10 @@ class Saml2AwsHelper:
                 try:
                     if "(" in line:
                         # Account: ALIAS (ACCOUNT_NUMBER)
-                        acc_name, acc_id = (
-                            line.replace("(", "")
-                            .replace(")", "")
-                            .split(" ")[1:]
-                        )
+                        acc_name, acc_id = (line.replace("(", "").replace(")", "").split(" ")[1:])
                     else:
                         # Account: ACCOUNT_NUMBER
-                        acc_namee, acc_id = "None", line.split(" ")[1]
+                        acc_name, acc_id = "None", line.split(" ")[1]
 
                     accounts_dict[acc_id] = acc_name
                 except Exception as e:
@@ -75,9 +70,7 @@ class Saml2AwsHelper:
         if self._session_duration:
             cmd = f"{cmd} --session-duration={self._session_duration}"
 
-        p = subprocess.Popen(
-            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-        )
+        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         for line in p.stdout.readlines():
             logging.debug(line.decode("utf-8").rstrip("\r|\n"))
         retval = p.wait()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __title__ = "saml2awsmulti"
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 __author__ = "Kay Hau"
 __email__ = "virtualda+github@gmail.com"
 __uri__ = "https://github.com/kyhau/saml2aws-multi"

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,11 @@ norecursedirs = env .tox
 # fail on XPASS
 xfail_strict = true
 
+[flake8]
+exclude = */tests/*
+ignore = E226,E302,E41
+max-line-length = 120
+
 # Inline coverage config
 [run]
 omit =

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py38,p739
+envlist = py38,py39,py310
 skip_missing_interpreters = True
 
 [testenv]
 basepython =
     py38: python3.8
     py39: python3.9
+    py310: python3.10
 install_command =
     python -m pip install {opts} {packages} -cconstraints.txt
 deps =
@@ -18,7 +19,7 @@ commands =
     pip check
     python -m pytest --junit-xml "junit-{envname}.xml"
 
-[testenv:py38]
+[testenv:py39]
 commands =
     pip check
     python -m pytest --cov . --cov-config=tox.ini --cov-report xml:coverage-{envname}.xml --junit-xml "junit-{envname}.xml" saml2awsmulti


### PR DESCRIPTION
- Updated `awslogin chained` to support option `--from-profile|-p` for showing chained roles from the ~/.aws/config for the given profile (specified with `from-profile|-p`).