### PR TITLE
Pomcho555 add browser autofill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+1.1.0 - 2024-12-21
+==================
+- Supported new option `--browser-autofill|-b` to enable browser-autofill in saml2aws
+
 1.0.1 - 2024-05-21
 ==================
 - Test with Python 3.12.
 - No longer test with Python 3.8 and Python 3.9.
-
 
 1.0.0 - 2023-02-15
 ==================

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Options:
                                   multi/aws_login_roles.csv.  [default: False]
 
   -t, --session-duration TEXT     Set the session duration in seconds,
+  -b, --browser-autofill          Enable browser-autofill.
   -d, --debug                     Enable debug mode.  [default: False]
   --help                          Show this message and exit.
 

--- a/saml2awsmulti/aws_login.py
+++ b/saml2awsmulti/aws_login.py
@@ -81,15 +81,16 @@ def pre_select_options(profile_rolearn_dict, keywords):
 @click.option("--refresh-cached-roles", "-r", is_flag=True, show_default=True,
     help=f"Re-retrieve the roles associated to the username and password you provided and save the roles into {ALL_ROLES_FILE}.")
 @click.option("--session-duration", "-t", help="Set the session duration in seconds.")
+@click.option("--browser-autofill", "-b", is_flag=True, show_default=True, help="Enable browser-autofill.")
 @click.option("--debug", "-d", is_flag=True, show_default=True, help="Enable debug mode.")
 @click.pass_context
-def main_cli(ctx, shortlisted, pre_select, profile_name_format, refresh_cached_roles, session_duration, debug):
+def main_cli(ctx, shortlisted, pre_select, profile_name_format, refresh_cached_roles, session_duration, browser_autofill, debug):
     if debug:
         logging.getLogger().setLevel(logging.DEBUG)
 
     if ctx.invoked_subcommand is None:
         try:
-            saml2aws_helper = Saml2AwsHelper(SAML2AWS_CONFIG_FILE, session_duration)
+            saml2aws_helper = Saml2AwsHelper(SAML2AWS_CONFIG_FILE, session_duration, browser_autofill)
 
             profile_rolearn_dict = create_profile_rolearn_dict(
                 saml2aws_helper,

--- a/saml2awsmulti/saml2aws_helper.py
+++ b/saml2awsmulti/saml2aws_helper.py
@@ -6,9 +6,10 @@ from saml2awsmulti.file_io import load_saml2aws_config
 
 
 class Saml2AwsHelper:
-    def __init__(self, configfile, session_duration):
+    def __init__(self, configfile, session_duration, browser_autofill):
         self._configfile = configfile
         self._session_duration = session_duration
+        self._browser_autofill = browser_autofill
         self._uname = None
         self._upass = None
 
@@ -69,6 +70,9 @@ class Saml2AwsHelper:
         cmd = f"saml2aws login --role={role_arn} -p {profile_name} --username={uname} --password={upass} --skip-prompt"
         if self._session_duration:
             cmd = f"{cmd} --session-duration={self._session_duration}"
+
+        if self._browser_autofill:
+            cmd = f"{cmd} --browser-autofill"
 
         p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         for line in p.stdout.readlines():

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __title__ = "saml2awsmulti"
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 __author__ = "kyhau"
 __email__ = "virtualda+github@gmail.com"
 __uri__ = "https://github.com/kyhau/saml2aws-multi"


### PR DESCRIPTION
## Proposed changes
- The original `saml2aws` provide `--browser-autofill` option to speed up your login, it's also nice to have this option through this tool.

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] Add or update tests that prove the fix is effective or that the feature works
- [x] Add or update workflows for deployment
- [x] Add or update README, CHANGELOG

## Outcome
- Explain the outcome of the change (screenshot or sample output if appropriate)
    saml2aws automatically fills the username and password on a browser after you filled them in the prompt of `awslogin`

- Are there any known use cases (or test cases) not covered by this change (or out of scope)?
    Compatibilities of each browser is out of scope of this PR since `saml2aws` does this job.

