### PR TITLE
fix: v1.3.1 — detect --stdin-password support at runtime (saml2aws < 2.37.0 compat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+1.3.1 - 2026-06-22
+==================
+- **Fixed compatibility with saml2aws < 2.37.0** — `--stdin-password` is now detected at runtime via `saml2aws login --help`; older binaries fall back to passing the password as a CLI argument
+
 1.3.0 - 2026-06-21
 ==================
 - **Added `awslogin clean` command** to remove expired credentials from `~/.aws/credentials`

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Before installing, ensure you have:
 2. **[saml2aws](https://github.com/Versent/saml2aws)** installed
    - See [install-saml2aws.sh](install-saml2aws.sh) for a Linux installation script
    - For other platforms, follow the [official installation guide](https://github.com/Versent/saml2aws#install)
+   - saml2aws ≥ 2.37.0 is recommended (supports `--stdin-password` for secure credential passing); older versions are supported via automatic fallback
 3. **saml2aws config file** (`~/.saml2aws`) - Run `saml2aws configure` to create
 
 ### Installation Options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "saml2awsmulti"
-version = "1.3.0"
+version = "1.3.1"
 description = "A helper script using saml2aws to login and retrieve AWS temporary credentials for multiple roles in different accounts."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -35,7 +35,7 @@ awslogin = "saml2awsmulti.aws_login:main_cli"
 # Poetry-specific configuration
 [tool.poetry]
 name = "saml2awsmulti"
-version = "1.3.0"
+version = "1.3.1"
 description = "A helper script using saml2aws to login and retrieve AWS temporary credentials for multiple roles in different accounts."
 authors = ["kyhau <virtualda+github@gmail.com>"]
 packages = [{include = "saml2awsmulti"}]

--- a/saml2awsmulti/saml2aws_helper.py
+++ b/saml2awsmulti/saml2aws_helper.py
@@ -12,6 +12,7 @@ class Saml2AwsHelper:
         self._browser_autofill = browser_autofill
         self._uname = None
         self._upass = None
+        self._stdin_password_supported = None
 
     def get_credentials(self):
         if self._uname is None or self._upass is None:
@@ -27,19 +28,47 @@ class Saml2AwsHelper:
 
         return self._uname, self._upass
 
+    def _supports_stdin_password(self):
+        """Detect whether the installed saml2aws binary supports --stdin-password."""
+        if self._stdin_password_supported is None:
+            result = subprocess.run(
+                ["saml2aws", "login", "--help"],
+                capture_output=True,
+                text=True,
+            )
+            self._stdin_password_supported = "--stdin-password" in (result.stdout + result.stderr)
+        return self._stdin_password_supported
+
     def run_saml2aws_list_roles(self):
         """Return List of (role_arn, account_name)"""
         roles = []
         accounts_dict = {}
         uname, upass = self.get_credentials()
 
-        # Avoid exposing the password in the process list by using --stdin-password.
-        cmd = ["saml2aws", "list-roles", f"--username={uname}", "--skip-prompt", "--stdin-password"]
-
-        p = subprocess.Popen(
-            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-        )
-        stdout, _ = p.communicate(input=(upass + "\n").encode())
+        if self._supports_stdin_password():
+            # Avoid exposing the password in the process list by using --stdin-password.
+            cmd = [
+                "saml2aws",
+                "list-roles",
+                f"--username={uname}",
+                "--skip-prompt",
+                "--stdin-password",
+            ]
+            p = subprocess.Popen(
+                cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            )
+            stdout, _ = p.communicate(input=(upass + "\n").encode())
+        else:
+            # Fallback for saml2aws versions that predate --stdin-password support.
+            cmd = [
+                "saml2aws",
+                "list-roles",
+                f"--username={uname}",
+                f"--password={upass}",
+                "--skip-prompt",
+            ]
+            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            stdout, _ = p.communicate()
 
         for line in stdout.decode("utf-8").splitlines():
             logging.debug(line)
@@ -70,27 +99,46 @@ class Saml2AwsHelper:
         logging.info(f"Adding {profile_name}...")
 
         uname, upass = self.get_credentials()
-        # Avoid exposing the password in the process list by using --stdin-password.
-        cmd = [
-            "saml2aws",
-            "login",
-            f"--role={role_arn}",
-            "-p",
-            profile_name,
-            f"--username={uname}",
-            "--skip-prompt",
-            "--stdin-password",
-        ]
-        if self._session_duration:
-            cmd.append(f"--session-duration={self._session_duration}")
 
-        if self._browser_autofill:
-            cmd.append("--browser-autofill")
+        if self._supports_stdin_password():
+            # Avoid exposing the password in the process list by using --stdin-password.
+            cmd = [
+                "saml2aws",
+                "login",
+                f"--role={role_arn}",
+                "-p",
+                profile_name,
+                f"--username={uname}",
+                "--skip-prompt",
+                "--stdin-password",
+            ]
+            if self._session_duration:
+                cmd.append(f"--session-duration={self._session_duration}")
+            if self._browser_autofill:
+                cmd.append("--browser-autofill")
+            p = subprocess.Popen(
+                cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            )
+            stdout, _ = p.communicate(input=(upass + "\n").encode())
+        else:
+            # Fallback for saml2aws versions that predate --stdin-password support.
+            cmd = [
+                "saml2aws",
+                "login",
+                f"--role={role_arn}",
+                "-p",
+                profile_name,
+                f"--username={uname}",
+                f"--password={upass}",
+                "--skip-prompt",
+            ]
+            if self._session_duration:
+                cmd.append(f"--session-duration={self._session_duration}")
+            if self._browser_autofill:
+                cmd.append("--browser-autofill")
+            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            stdout, _ = p.communicate()
 
-        p = subprocess.Popen(
-            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-        )
-        stdout, _ = p.communicate(input=(upass + "\n").encode())
         for line in stdout.decode("utf-8").splitlines():
             logging.debug(line)
         retval = p.returncode

--- a/tests/test_saml2aws_helper.py
+++ b/tests/test_saml2aws_helper.py
@@ -13,6 +13,7 @@ class TestSaml2AwsHelper:
         assert helper._browser_autofill is True
         assert helper._uname is None
         assert helper._upass is None
+        assert helper._stdin_password_supported is None
 
     @patch("saml2awsmulti.saml2aws_helper.load_saml2aws_config")
     @patch("builtins.input")
@@ -80,6 +81,7 @@ class TestSaml2AwsHelper:
         mock_popen.return_value = mock_process
 
         helper = Saml2AwsHelper("config_file", None, False)
+        helper._stdin_password_supported = True
         result = helper.run_saml2aws_list_roles()
 
         expected = [
@@ -113,6 +115,7 @@ class TestSaml2AwsHelper:
         mock_popen.return_value = mock_process
 
         helper = Saml2AwsHelper("config_file", None, False)
+        helper._stdin_password_supported = True
         result = helper.run_saml2aws_list_roles()
 
         expected = [("arn:aws:iam::123456789012:role/dev", "None")]
@@ -132,6 +135,7 @@ class TestSaml2AwsHelper:
         mock_popen.return_value = mock_process
 
         helper = Saml2AwsHelper("config_file", None, False)
+        helper._stdin_password_supported = True
 
         with pytest.raises(ValueError, match="Failed to retrieve roles with saml2aws"):
             helper.run_saml2aws_list_roles()
@@ -155,6 +159,7 @@ class TestSaml2AwsHelper:
         mock_popen.return_value = mock_process
 
         helper = Saml2AwsHelper("config_file", None, False)
+        helper._stdin_password_supported = True
 
         result = helper.run_saml2aws_list_roles()
 
@@ -184,6 +189,7 @@ class TestSaml2AwsHelper:
 
         with caplog.at_level("ERROR"):
             helper = Saml2AwsHelper("config_file", None, False)
+            helper._stdin_password_supported = True
             result = helper.run_saml2aws_list_roles()
 
         assert result == [("arn:aws:iam::123456789012:role/dev", "aws-01")]
@@ -202,6 +208,7 @@ class TestSaml2AwsHelper:
         mock_popen.return_value = mock_process
 
         helper = Saml2AwsHelper("config_file", None, False)
+        helper._stdin_password_supported = True
         result = helper.run_saml2aws_login("arn:aws:iam::123456789012:role/dev", "dev")
 
         assert result == 0
@@ -222,6 +229,7 @@ class TestSaml2AwsHelper:
         mock_popen.return_value = mock_process
 
         helper = Saml2AwsHelper("config_file", "7200", False)
+        helper._stdin_password_supported = True
         helper.run_saml2aws_login("arn:aws:iam::123456789012:role/dev", "dev")
 
         # Check that session duration was included in command
@@ -243,6 +251,7 @@ class TestSaml2AwsHelper:
         mock_popen.return_value = mock_process
 
         helper = Saml2AwsHelper("config_file", None, True)
+        helper._stdin_password_supported = True
         helper.run_saml2aws_login("arn:aws:iam::123456789012:role/dev", "dev")
 
         # Check that browser autofill was included in command
@@ -262,6 +271,7 @@ class TestSaml2AwsHelper:
         mock_popen.return_value = mock_process
 
         helper = Saml2AwsHelper("config_file", None, False)
+        helper._stdin_password_supported = True
         result = helper.run_saml2aws_login("arn:aws:iam::123456789012:role/dev", "dev")
 
         assert result == 1
@@ -279,6 +289,7 @@ class TestSaml2AwsHelper:
         mock_popen.return_value = mock_process
 
         helper = Saml2AwsHelper("config_file", "3600", True)
+        helper._stdin_password_supported = True
         helper.run_saml2aws_login("arn:aws:iam::123456789012:role/dev", "dev")
 
         # Verify the command is a list (no shell=True) and contains expected args
@@ -298,3 +309,82 @@ class TestSaml2AwsHelper:
         assert not any("testpass" in arg for arg in call_args)
         # Password sent via stdin
         mock_process.communicate.assert_called_once_with(input=b"testpass\n")
+
+    @patch("subprocess.run")
+    def test_supports_stdin_password_true(self, mock_run):
+        mock_run.return_value = Mock(
+            stdout="--stdin-password  Read password from stdin\n", stderr=""
+        )
+        helper = Saml2AwsHelper("config_file", None, False)
+        assert helper._supports_stdin_password() is True
+        mock_run.assert_called_once_with(
+            ["saml2aws", "login", "--help"], capture_output=True, text=True
+        )
+
+    @patch("subprocess.run")
+    def test_supports_stdin_password_false(self, mock_run):
+        mock_run.return_value = Mock(stdout="--password  The password\n", stderr="")
+        helper = Saml2AwsHelper("config_file", None, False)
+        assert helper._supports_stdin_password() is False
+
+    @patch("subprocess.run")
+    def test_supports_stdin_password_cached(self, mock_run):
+        mock_run.return_value = Mock(stdout="--stdin-password\n", stderr="")
+        helper = Saml2AwsHelper("config_file", None, False)
+        helper._supports_stdin_password()
+        helper._supports_stdin_password()
+        mock_run.assert_called_once()
+
+    @patch("saml2awsmulti.saml2aws_helper.load_saml2aws_config")
+    @patch("getpass.getpass")
+    @patch("subprocess.Popen")
+    def test_run_saml2aws_list_roles_fallback_password_in_args(
+        self, mock_popen, mock_getpass, mock_load_config
+    ):
+        mock_load_config.return_value = {"username": "testuser"}
+        mock_getpass.return_value = "testpass"
+
+        mock_process = Mock()
+        mock_process.communicate.return_value = (
+            b"Account: aws-01 (123456789012)\narn:aws:iam::123456789012:role/dev\n",
+            None,
+        )
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        helper = Saml2AwsHelper("config_file", None, False)
+        helper._stdin_password_supported = False
+        result = helper.run_saml2aws_list_roles()
+
+        assert result == [("arn:aws:iam::123456789012:role/dev", "aws-01")]
+        cmd_args = mock_popen.call_args[0][0]
+        assert "--stdin-password" not in cmd_args
+        assert "--password=testpass" in cmd_args
+        # Password passed via args, not stdin
+        mock_process.communicate.assert_called_once_with()
+
+    @patch("saml2awsmulti.saml2aws_helper.load_saml2aws_config")
+    @patch("getpass.getpass")
+    @patch("subprocess.Popen")
+    def test_run_saml2aws_login_fallback_password_in_args(
+        self, mock_popen, mock_getpass, mock_load_config
+    ):
+        mock_load_config.return_value = {"username": "testuser"}
+        mock_getpass.return_value = "testpass"
+
+        mock_process = Mock()
+        mock_process.communicate.return_value = (b"Login successful\n", None)
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        helper = Saml2AwsHelper("config_file", "3600", True)
+        helper._stdin_password_supported = False
+        helper.run_saml2aws_login("arn:aws:iam::123456789012:role/dev", "dev")
+
+        cmd_args = mock_popen.call_args[0][0]
+        assert "--stdin-password" not in cmd_args
+        assert "--password=testpass" in cmd_args
+        assert "--session-duration=3600" in cmd_args
+        assert "--browser-autofill" in cmd_args
+        # Password passed via args, not stdin
+        mock_process.communicate.assert_called_once_with()


### PR DESCRIPTION
## Problem
`--stdin-password` was introduced in saml2aws v2.37.0. The v1.3.0 security fix unconditionally uses this flag, breaking users on older binaries (e.g. Homebrew currently ships 2.36.19).

## Solution
Detect support at runtime by inspecting `saml2aws login --help` output (result cached per session):
- **saml2aws ≥ 2.37.0**: use `--stdin-password` + stdin pipe (secure, no password in process list)
- **saml2aws < 2.37.0**: fall back to `--password=` CLI arg

## Changes
- `saml2aws_helper.py`: add `_supports_stdin_password()`; branch both `run_saml2aws_list_roles` and `run_saml2aws_login`
- `test_saml2aws_helper.py`: 5 new tests (detection + fallback paths); 90 tests total, all passing
- `pyproject.toml`: bump to 1.3.1
- `CHANGELOG.md`: add 1.3.1 entry
- `README.md`: note saml2aws ≥ 2.37.0 recommended with fallback for older versions